### PR TITLE
deps/ssp: bump to v0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "ssp"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e492166d4e78bcb4380b5799867db1c0763cc2c783854f32a52955987744478"
+checksum = "42741febbf98c8f0be8139e53f822c0210dd3a3dae7ed4c04e2a561484ad4d66"
 dependencies = [
  "aes",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ signal-hook = "0.3"
 rustyline = "11.0"
 
 [dependencies.ssp]
-version = "0.2"
+version = "0.3"
 features = ["jsonrpc", "std"]


### PR DESCRIPTION
Bumps the `ssp` dependency to the latest version to include changes to the `DeviceStatus` struct, and message parsing.